### PR TITLE
Performance improvement: Optional mean error calculation

### DIFF
--- a/src/radviz.js
+++ b/src/radviz.js
@@ -363,7 +363,13 @@ export default function Radviz() {
 
             sum_mean_distance = sum_mean_distance + Math.sqrt(Math.pow(point['x1'], 2) + Math.pow(point['x2'], 2))
         })
-        mean_error_e = calculateErrorE()
+
+        // only do this costly mean error calculation if necessary, i.e., when a callback has been
+        // registered that uses the metric.
+        if (function_update_results !== null) {
+            mean_error_e = calculateErrorE()
+        }
+
         mean_distance = sum_mean_distance / data.entries.length
     }
     let drawGrid = function() {


### PR DESCRIPTION
During my own testing with large datasets, I noticed that the function ```calculateErrorE()```, called only in one place at the end of ```calculatePointPosition()```, takes up to 50% of the rendering time of radviz. It turns out that it's output, the variable ```mean_error_e```, is only used by the optional (as in potentially ```null```), user-provided callback ```function_update_results```. 

* [```5dae3b9bfe```](https://github.com/aware-diag-sapienza/d3-radviz/commit/5dae3b9bfe4aada0c766fab6a4928ed3f7f95fda): To reduce rendering time of radviz on large datasets, avoid the expensive calculation of ```mean_error_e```, in case no callback has been provided.